### PR TITLE
Add final URLs to slides

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,11 +6,11 @@ See https://docs.asciidoctor.org/reveal.js-converter/latest/setup/node-js-setup/
 
 * [x] Setup structure and include in presentation.adoc
 * [x] Import white.css theme and customize to meet Systel-CI
-* [ ] Release clean version to github.com
-* [ ] Add github-Actions to build an merge to main
-* [ ] Configure github-pages
-* [ ] Add URL of presentation to slides
-* [ ] Add URL of page to edit feedback to slides
+* [x] Release clean version to github.com
+* [x] Add github-Actions to build an merge to main
+* [x] Configure github-pages
+* [x] Add URL of presentation to slides
+* [x] Add URL of page to edit feedback to slides
 
 == License
 

--- a/devops.adoc
+++ b/devops.adoc
@@ -26,6 +26,16 @@ Dev und Ops wachsen zusammen.
 * GitHub Actions Pipeline, um automatisch die Slides zu generieren (CI)
 * GitHub Pages als Produktions-System (CD)
 
+=== Slides
+
+GitHub Repository:
+
+https://github.com/dbsystel/deepdive-devops-innersource-opensource
+
+Präsentation:
+
+https://dbsystel.github.io/deepdive-devops-innersource-opensource/presentation.html
+
 === Barrieren abbauen
 [.pattern-jigsaw]
 --

--- a/open_source.adoc
+++ b/open_source.adoc
@@ -121,7 +121,8 @@ Zusammenarbeit über Organisationsgrenzen hinweg
 
 === Hands-on Demo
 
-https://github.com/dbsystel/deep-dive-devops-innersource-opensource
+[.small]
+https://github.com/dbsystel/deepdive-devops-innersource-opensource/blob/main/feedback.adoc
 
 [.notes]
 --


### PR DESCRIPTION
This pull request adds the URLs to the final slides to the presentation.

The URLs for the repository and the rendered slides are in the DevOps section after the slide about "Slides as Code" and before the demo. So this can be explained in one go. Alternatively we could also put the URLs at the beginning after the agenda slide.